### PR TITLE
Add status check for multiple articles.

### DIFF
--- a/server/public_html/osmjson/getGeoJSON.php
+++ b/server/public_html/osmjson/getGeoJSON.php
@@ -10,6 +10,17 @@ $lang = $_GET['lang'];
 
 $wiwosm = new Wiwosm();
 
+// status check for multiple, comma-separated articles
+if ($_GET['action'] == 'check' && $lang && $_GET['articles']) {
+	header('Content-Encoding: text/plain');
+	$articles = split(',', $_GET['articles']);
+	foreach ($articles as $article) {
+		$file = $wiwosm->getFilePath($lang, $article);
+		print "$article\t" . (file_exists($file) ? 1 : 0) . "\n";
+	}
+	exit();
+}
+
 if ($_GET['action']=='purge' && $article && $lang) {
 
 	// no output please


### PR DESCRIPTION
Check several Wikipedia articles for existing WIWOSM file at once.
Input: comma-separated list of articles
Output: [article][tabulator][existing ? 1 : 0]

I would like to use this in the JOSM Wikipedia plugin. Separate requests per article are too slow.
